### PR TITLE
Automate ToC generation via pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+README.md.*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/github-markdown-toc"]
+	path = tools/github-markdown-toc
+	url = https://github.com/ekalinin/github-markdown-toc/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tools/github-markdown-toc"]
-	path = tools/github-markdown-toc
-	url = https://github.com/ekalinin/github-markdown-toc/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ PHP Core Telegram for Pokemon Bots providing core communication with Telegram an
 
 The PHP Core Telegram repo is required by [PokemonRaidBot](https://github.com/florianbecker/PokemonRaidBot) and [PokemonQuestBot](https://github.com/florianbecker/PokemonQuestBot).
 
+# Table of contents
+<!--ts-->
+   * [PHP Core Telegram for Pokemon Bots](#php-core-telegram-for-pokemon-bots)
+   * [About](#about)
+   * [Table of contents](#table-of-contents)
+   * [Git clone](#git-clone)
+   * [Access permissions](#access-permissions)
+      * [Permissions overview](#permissions-overview)
+   * [Usage](#usage)
+      * [Bot commands](#bot-commands)
+         * [Command: /getconfig](#command-getconfig)
+         * [Command: /setconfig](#command-setconfig)
+
+<!-- Added by: artanicus, at: Mon Nov 18 22:19:44 EET 2019 -->
+
+<!--te-->
+
 # Git clone
 
 It is recommended to look at the READMEs from the Bots which require the PHP Core Telegram stuff.

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,29 +3,50 @@
 # Debug
 # set -x
 
-# Tell the user we run a pre-commit hook
-echo 'Running pre-commit hook'
+regen_toc(){
+  # Tell the user we run a pre-commit hook
+  echo 'Running pre-commit hook for README.md ToC'
+  tools/github-markdown-toc/gh-md-toc --insert README.md
+  git add README.md
+}
 
-# Old version
-OLD_VERSION=$(cat VERSION)
-echo 'Current version:' $OLD_VERSION
 
-# Build new version string
-MAJOR=$(date +%y | cut -c1)
-MINOR=$(date +%y | cut -c2)
-DAY=$(date +%j)
-COMMIT=$((`git rev-list --count --since=midnight HEAD` + 1))
-VERSION=$MAJOR.$MINOR.$DAY.$COMMIT
 
-# Update version file
-echo 'Updating project version to:' $VERSION
-echo $VERSION > VERSION
+regen_version(){
+  # Old version
+  OLD_VERSION=$(cat VERSION)
+  echo 'Current version:' $OLD_VERSION
 
-# Add version file to commit
-echo 'Adding new version to commit'
-echo
-git add VERSION
+  # Build new version string
+  MAJOR=$(date +%y | cut -c1)
+  MINOR=$(date +%y | cut -c2)
+  DAY=$(date +%j)
+  COMMIT=$((`git rev-list --count --since=midnight HEAD` + 1))
+  VERSION=$MAJOR.$MINOR.$DAY.$COMMIT
 
-# Interrupt, so user can see output before commit
-read -p "Press any key to continue..." </dev/tty
-echo
+  # Update version file
+  echo 'Updating project version to:' $VERSION
+  echo $VERSION > VERSION
+
+  # Add version file to commit
+  echo 'Adding new version to commit'
+  echo
+  git add VERSION
+
+  # Interrupt, so user can see output before commit
+  read -p "Press any key to continue..." pause
+  echo
+}
+
+# Tell the user we're running pre-commit hooks
+echo 'Running pre-commit hooks'
+
+# Only run the ToC regen hook if README.md has been staged
+git diff --cached --name-only --diff-filter=ACM | grep README.md && regen_toc
+
+# Run version regen on every commit if VERSION file present
+# TODO(artanicus): Is this truly the intention, to run at every commit? And should the update also go to the sample config?
+[ -f VERSION ] && regen_version
+
+# exit cleanly to let commit continue
+exit 0


### PR DESCRIPTION
Prepwork on the core side to add a ToC regen hook, rewrite the pre-commit hook to run multiple automations and trigger them only if conditions are met.
Since the VERSION update didn't have a condition I added a check for the file being present. This allows the same pre-commit hook to be used in all the bot repos and it'll only update VERSION where that is wanted.