### PR TITLE
Restore submodule definition for github-markdown-toc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/github-markdown-toc"]
+	path = tools/github-markdown-toc
+	url = https://github.com/ekalinin/github-markdown-toc/

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Debug
 # set -x


### PR DESCRIPTION
The tool is used for regenerating a Table of Contents on commit. If you
enable the pre-commit hook provided this will be run automagically for
you on any README.md changes.