### PR TITLE
Finish support for DB schema upgrades

### DIFF
--- a/bot/logic/sql_utils.php
+++ b/bot/logic/sql_utils.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * run_sql_file, executes the given file path sql and returns true if no errors occurred
+ * @param $raid
+ * @return bool
+ */
+function run_sql_file($file) {
+  global $dbh;
+  if (!$dbh) {
+    error_log('No DB handle!');
+    return false;
+  } 
+  try {
+    $query = file_get_contents($file);
+    $statement = $dbh->prepare( $query );
+    $statement->execute();
+  }
+  catch (PDOException $exception) {
+  }
+  catch (PDOException $exception) {
+    debug_log('DB upgrade failed: ' . $exception->getMessage());
+    error_log($exception->getMessage());
+    $dbh = null;
+    return false;
+  }
+  return true;
+}
+?>

--- a/bot/version.php
+++ b/bot/version.php
@@ -63,7 +63,8 @@ if($nodot_current == $nodot_latest) {
         debug_log('Your bot version: ' . $current);
         debug_log('Latest bot version: ' . $latest);
         debug_log('Performing bot upgrade check now...');
-        $upgrade = bot_upgrade_check($current, $latest);
+        require_once('db.php');
+        $upgrade = bot_upgrade_check($current, $latest, $dbh);
 
         // Upgrade needed?
         if(!$upgrade) {


### PR DESCRIPTION
If enabled in the config (enabled by default in both bots with revisions that pin this one) performs DB schema upgrades automagically based on config versions.

This relies on:
- Devs that cause schema changes in the bots themselves need to create a file `sql/upgrade/$VERSION.sql` that performs the necessary ALTER steps.
- The config being writable by the user running php

Also:
- Now config migrations actually write out the changes. It's naive though and writes it out every time which is a bit bad.